### PR TITLE
feat: add warning message on profile management screens

### DIFF
--- a/dashboard/public/components/registration-page.css
+++ b/dashboard/public/components/registration-page.css
@@ -52,7 +52,7 @@ h2+aside {
 }
 
 #MainCard .Main-Content {
-    height: 275px;
+    height: 350px;
 }
 
 neon-animatable {

--- a/dashboard/public/components/resources/md2-input/md2-input.css
+++ b/dashboard/public/components/resources/md2-input/md2-input.css
@@ -53,3 +53,17 @@ input {
     @apply --paper-input-error;
     @apply --md2-error;
 }
+.paper-material {
+    display: inline-block;
+    box-sizing: border-box;
+    padding: 1rem;
+    color: var(--paper-grey-800);
+    background-color: var(--paper-grey-50);
+    @apply --shadow-elevation-2dp;
+    @apply --paper-material;
+}
+.paper-material h3 {
+    margin: 0;
+    font-size: 1.2rem;
+    color: var(--paper-red-500);
+}

--- a/dashboard/public/components/resources/md2-input/md2-input.pug
+++ b/dashboard/public/components/resources/md2-input/md2-input.pug
@@ -7,3 +7,18 @@
     slot(name='suffix', slot='suffix')
     iron-a11y-keys#keys(target='[[inputElement]]', keys='enter', on-keys-pressed='fireEnter')
 aside.Error [[error]]
+
+div(class="paper-material")
+    h3 WARNING
+    p
+        | deployKF does
+        |
+        strong NOT
+        |
+        | support managing profiles through this interface.
+        br
+        | Please see the
+        |
+        a(href='https://www.deploykf.org/guides/platform/deploykf-profiles/') profile management
+        |
+        | guide.


### PR DESCRIPTION
<!-- 
⚠️ please review https://github.com/deployKF/deployKF/blob/main/CONTRIBUTING.md

Thank you for contributing to deployKF!

If there are related issues, please reference them using one of the following:

 closes: #ISSUE
 related: #ISSUE

Please remember:
 - provide enough information so that others can review your pull request
 - use a semantic title for your pull request (like "fix: xxxxx" or "feat: xxxxx", see contributing guide)
 - the title of your pull request will be used to generate the changelog entry, so make it count!
-->
This PR adds a warning on the "Manage Contributors" page, saying that deployKF does not support using the UI to manage profiles.

In a separate PR we will also block the KFAM API paths that these pages use.